### PR TITLE
Don't resync papers that were renamed or deleted

### DIFF
--- a/morningpaper.go
+++ b/morningpaper.go
@@ -110,6 +110,16 @@ func downloadFilesFromFeed(page int) error {
 		// Use the item title here because Adrian uses better titles than
 		// what is usually in the link for the paper.
 		file := filepath.Join(dataDir, name)
+
+		if paperAlreadySynced(file) {
+			logrus.WithFields(logrus.Fields{
+				"paper": paper.Text(),
+				"link":  paperLink,
+			}).Info("skipping paper (already synced)")
+
+			continue
+		}
+
 		if err := downloadPaper(paperLink, file); err != nil {
 			return err
 		}
@@ -130,6 +140,12 @@ func downloadFilesFromFeed(page int) error {
 	}
 
 	return nil
+}
+
+func paperAlreadySynced(file string) bool {
+	// check if file exists
+	_, err := os.Stat(file)
+	return err == nil
 }
 
 func downloadPaper(link, file string) error {


### PR DESCRIPTION
Running in daemon mode currently means that papers that you deleted/renamed on your remarkable get reuploaded every time the interval is finished. 

This pull request introduces a check if the paper was uploaded to the remarkable in an earlier run (if the file exists on disk) and if so skips it.